### PR TITLE
Update Dockerfile to slim final container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM python:alpine
+FROM alpine:3.5
 
 #Change these values dependant on your environment
 ENV MQTT="test.mosquitto.org" MQTTPORT=1883 NETINT="enp0s3"
 
+RUN    echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories \
+    && apk add -Uuv --no-cache snort daq supervisor python2 python3 \
+    && apk upgrade -v --available --no-cache
 
-RUN pip install --upgrade pip setuptools wheel
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN    pip3 install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip3 install --no-cache-dir -r requirements.txt
 
 #Copy applications
 COPY snort_socket.py .
@@ -16,13 +19,7 @@ COPY super_snort.conf .
 COPY simple_snort.conf /etc/snort/simple_snort.conf
 COPY rules /etc/snort/rules
 
-#Replace apk directories with the latest directories
-RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories
-
-RUN apk upgrade --update-cache --available
-RUN apk add --no-cache snort daq supervisor git
-
-RUN sed -i '/import alert/c\import snortunsock.alert as alert' /usr/local/lib/python3.6/site-packages/snortunsock/snort_listener.py
+RUN sed -i '/import alert/c\import snortunsock.alert as alert' /usr/lib/python3.6/site-packages/snortunsock/snort_listener.py
 
 EXPOSE 5000
 


### PR DESCRIPTION
Modified Dockerfile to build a smaller container:

* Reworked ordering of some of the container RUN operations
* Removed `git`
* Used options to inhibit caching

Ultimate this reduced the resulting container by ~75MB in my test:

```shell
$ docker images | grep snort_
snorty_mcsnort_face                                                                    slimmer                      cf4620123c50        5 seconds ago       120 MB
snorty_mcsnort_face                                                                    master                       3c477fd9d843        3 minutes ago       195 MB
```

It should operate the same, though I haven't tested in detail.
